### PR TITLE
Move theme toggle to floating control and default to dark theme

### DIFF
--- a/app/components/layout/SiteHeader.vue
+++ b/app/components/layout/SiteHeader.vue
@@ -77,7 +77,10 @@ onBeforeUnmount(() => {
         <span class="flex h-10 w-10 items-center justify-center rounded-lg bg-brand text-white shadow-lg shadow-brand/30">FS</span>
         <span>Fake Store Dashboard</span>
       </NuxtLink>
-      <nav class="hidden items-center gap-2 text-sm font-medium text-slate-600 transition-colors duration-200 md:flex md:flex-wrap md:justify-end md:gap-4 lg:gap-6 dark:text-slate-200">
+      <nav
+        aria-label="Primary navigation"
+        class="hidden items-center gap-2 text-sm font-medium text-slate-600 transition-colors duration-200 md:flex md:flex-wrap md:justify-end md:gap-4 lg:gap-6 dark:text-slate-200"
+      >
         <NuxtLink
           v-for="item in navigation"
           :key="item.to"
@@ -98,7 +101,6 @@ onBeforeUnmount(() => {
           </template>
         </NuxtLink>
         <LanguageSwitcher />
-        <ThemeToggle />
         <span
           v-if="auth.user"
           class="rounded-full bg-slate-100 px-4 py-1 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-200"
@@ -146,7 +148,10 @@ onBeforeUnmount(() => {
           id="site-navigation-mobile"
           class="md:hidden"
         >
-          <nav class="absolute inset-x-0 top-full z-50 border-b border-slate-200 bg-white/95 px-4 py-4 text-sm font-medium text-slate-600 shadow-lg shadow-slate-900/5 backdrop-blur dark:border-slate-800 dark:bg-slate-900/95 dark:text-slate-200">
+          <nav
+            aria-label="Primary navigation"
+            class="absolute inset-x-0 top-full z-50 border-b border-slate-200 bg-white/95 px-4 py-4 text-sm font-medium text-slate-600 shadow-lg shadow-slate-900/5 backdrop-blur dark:border-slate-800 dark:bg-slate-900/95 dark:text-slate-200"
+          >
             <NuxtLink
               v-for="item in navigation"
               :key="item.to"
@@ -157,7 +162,6 @@ onBeforeUnmount(() => {
             </NuxtLink>
             <div class="flex items-center justify-between gap-3 px-3 py-2">
               <LanguageSwitcher />
-              <ThemeToggle />
             </div>
             <span v-if="auth.user" class="block px-3 text-xs text-slate-500 dark:text-slate-300">
               {{ $t('header.welcome', { name: auth.user.username }) }}

--- a/app/components/layout/ThemeToggle.vue
+++ b/app/components/layout/ThemeToggle.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, withDefaults } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useThemeStore } from '~/stores/theme'
+
+const props = withDefaults(defineProps<{ variant?: 'inline' | 'floating' }>(), {
+  variant: 'inline',
+})
 
 const themeStore = useThemeStore()
 const { t } = useI18n()
@@ -11,14 +15,22 @@ const isDark = computed(() => themeStore.preference === 'dark')
 const toggleTheme = () => {
   themeStore.toggle()
 }
+
+const buttonClasses = computed(() =>
+  props.variant === 'floating'
+    ? 'inline-flex h-12 w-12 items-center justify-center rounded-full border border-slate-300/60 bg-white/80 text-slate-700 shadow-lg shadow-slate-900/10 ring-1 ring-slate-900/5 transition hover:bg-white dark:border-slate-600 dark:bg-slate-800/90 dark:text-slate-100 dark:shadow-black/20 dark:hover:bg-slate-700'
+    : 'flex items-center gap-2 rounded-full border border-slate-300/60 bg-white/70 px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm transition hover:bg-white dark:border-slate-600 dark:bg-slate-800/80 dark:text-slate-100 dark:hover:bg-slate-700',
+)
 </script>
 
 <template>
   <ClientOnly>
     <button
       type="button"
-      class="flex items-center gap-2 rounded-full border border-slate-300/60 bg-white/70 px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm transition hover:bg-white dark:border-slate-600 dark:bg-slate-800/80 dark:text-slate-100 dark:hover:bg-slate-700"
+      class="focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+      :class="buttonClasses"
       :aria-pressed="isDark"
+      :aria-label="t('header.theme.toggleLabel')"
       :title="isDark ? t('header.theme.light') : t('header.theme.dark')"
       @click="toggleTheme"
     >
@@ -50,7 +62,9 @@ const toggleTheme = () => {
         <circle cx="12" cy="12" r="4" />
         <path d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-6.364l-1.414 1.414M8.05 15.95l-1.414 1.414m0-11.314l1.414 1.414m10.607 10.607l-1.414-1.414" />
       </svg>
-      <span class="hidden sm:inline">{{ isDark ? t('header.theme.light') : t('header.theme.dark') }}</span>
+      <span v-if="props.variant === 'inline'" class="hidden sm:inline"
+        >{{ isDark ? t('header.theme.light') : t('header.theme.dark') }}</span
+      >
     </button>
   </ClientOnly>
 </template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -28,6 +28,13 @@ const head = useLocaleHead({
         </main>
         <!-- 網站頁尾 -->
         <SiteFooter />
+        <ClientOnly>
+          <Teleport to="body">
+            <div class="fixed bottom-6 right-6 z-[60]">
+              <ThemeToggle variant="floating" />
+            </div>
+          </Teleport>
+        </ClientOnly>
       </div>
     </Body>
   </Html>

--- a/app/stores/theme.ts
+++ b/app/stores/theme.ts
@@ -14,12 +14,6 @@ const getStorage = () => {
   }
 }
 
-const getSystemPreference = (): ThemePreference => {
-  if (!process.client) return 'dark'
-  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false
-  return prefersDark ? 'dark' : 'light'
-}
-
 export const useThemeStore = defineStore('theme', {
   state: () => ({
     preference: 'dark' as ThemePreference,
@@ -44,7 +38,7 @@ export const useThemeStore = defineStore('theme', {
 
       const storage = getStorage()
       const stored = storage?.getItem(STORAGE_KEY) as ThemePreference | null
-      const resolved = stored === 'light' || stored === 'dark' ? stored : getSystemPreference()
+      const resolved = stored === 'light' || stored === 'dark' ? stored : 'dark'
 
       this.preference = resolved
       this.hydrated = true


### PR DESCRIPTION
## Summary
- move the theme toggle out of the header into a floating bottom-right control and enhance accessibility styling
- default theme preference to dark when no saved choice exists
- add navigation aria labels to reinforce semantic markup

## Testing
- npm run lint *(fails: script missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925d9b046f0833094422c10177f648f)